### PR TITLE
#104 Add arm64 platform to GH Actions docker image to support Mac M1

### DIFF
--- a/.github/workflows/docker-pypi-publish.yml
+++ b/.github/workflows/docker-pypi-publish.yml
@@ -59,7 +59,7 @@ jobs:
         run: python -m build
 
       - name: Store the distribution packages
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: python-package-distributions
           path: dist/
@@ -95,6 +95,12 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -120,6 +126,7 @@ jobs:
         uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,3 +19,5 @@ COPY ./rq_dashboard_fast /app/rq_dashboard_fast
 COPY app.py /app
 
 WORKDIR /app
+
+CMD ["python3", "app.py"]

--- a/README.md
+++ b/README.md
@@ -69,8 +69,7 @@ Replace <your_fastapi_port> with your desired FastAPI and host port.
 
 2. You can use Docker Compose by creating a docker-compose.yml file:
 
-```
-version: '3.11'
+```yml
 services:
   dashboard:
     image: hannes221/rq-dashboard-fast
@@ -94,8 +93,7 @@ http://127.0.0.1:8000/rq
 
 To change the part update the compose file:
 
-```
-version: '3.11'
+```yml
 services:
   dashboard:
     image: hannes221/rq-dashboard-fast

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.11'
 services:
   dashboard:
     build:


### PR DESCRIPTION
Fixes #104 

actions/upload-artifact@v3 -> v4 because v3 not working now and build fails:

https://github.com/Mayurifag/rq-dashboard-fast/actions/runs/16402749281/job/46344484329
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

docker-compose's -> versions deleted because they're obsoleted and in builds it gives warnings. `Build Docker image with dev dependencies` step:

https://github.com/Mayurifag/rq-dashboard-fast/actions/runs/16402749281/job/46344467822

------------

Check upload of arm64 docker image:
https://github.com/Mayurifag/rq-dashboard-fast/actions/runs/16402926906/job/46344884773

Check code is working example: <http://localhost:8001/rq>

```yml
  # ... rq-worker and dragonfly/redis working configurations

  rq-dashboard:
    image: mayurifag/rq-dashboard-fast:104-add-gh-actions-docker-platforms
    ports:
      - '8001:8000'
    depends_on:
      - rq-worker
    environment:
      - REDIS_URL=redis://dragonfly:6379
```