### PR TITLE
Adding cli startup commands and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,31 @@ PyPi: [rq-dashboard-fast](https://pypi.org/project/rq-dashboard-fast/)
 $ pip install rq-dashboard-fast
 ```
 
+## Running Standalone
+
+After installing, you can run the dashboard directly from the terminal:
+
+```
+$ rq-dashboard-fast
+```
+
+This starts the dashboard at `http://localhost:8000/rq` using Redis at `redis://localhost:6379`.
+
+Available options:
+
+```
+$ rq-dashboard-fast --help
+$ rq-dashboard-fast --redis-url redis://my-redis:6379 --port 9000
+$ rq-dashboard-fast --host 127.0.0.1 --prefix /dashboard
+```
+
+| Flag | Default | Environment Variable |
+|------|---------|---------------------|
+| `--redis-url` | `redis://localhost:6379` | `REDIS_URL` |
+| `--host` | `0.0.0.0` | `FASTAPI_HOST` |
+| `--port` | `8000` | `FASTAPI_PORT` |
+| `--prefix` | `/rq` | — |
+
 ## Running in Docker
 
 1. You can run the RQ Dashboard FastAPI as a Docker container with custom Redis URL:
@@ -124,7 +149,7 @@ $ pip install rq-dashboard-fast
 - [x] Add pagination to jobs page
 - [x] Data Export
 - [ ] Statistics Tab
-- [ ] Run Standalone (Terminal)
+- [x] Run Standalone (Terminal)
 
 ## Contributing
 

--- a/app.py
+++ b/app.py
@@ -1,18 +1,4 @@
-import os
-
-import uvicorn
-from fastapi import FastAPI
-
-from rq_dashboard_fast.rq_dashboard_fast import RedisQueueDashboard
-
-app = FastAPI()
-
-REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379")
-PORT = int(os.getenv("FASTAPI_PORT", 8000))
-
-dashboard = RedisQueueDashboard(redis_url=REDIS_URL, prefix="/rq")
-
-app.mount("/rq", dashboard)
+from rq_dashboard_fast.cli import main
 
 if __name__ == "__main__":
-    uvicorn.run(app, host="0.0.0.0", port=PORT)
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rq-dashboard-fast"
-version = "0.6.0"
+version = "0.6.1"
 description = "rq-dashboard-fast is a FastAPI-based dashboard to monitor your Redis-Queue (RQ) Jobs, Queues, and Workers"
 authors = ["Hannes221 <hannespfau@gmail.com>"]
 readme = "README.md"
@@ -29,6 +29,9 @@ flake8 = "^7.0.0"
 
 [tool.isort]
 profile = "black"
+
+[tool.poetry.scripts]
+rq-dashboard-fast = "rq_dashboard_fast.cli:main"
 
 [build-system]
 requires = ["poetry-core"]

--- a/rq_dashboard_fast/cli.py
+++ b/rq_dashboard_fast/cli.py
@@ -1,0 +1,39 @@
+import argparse
+import os
+
+import uvicorn
+from fastapi import FastAPI
+
+from rq_dashboard_fast import RedisQueueDashboard
+
+
+def main():
+    parser = argparse.ArgumentParser(description="RQ Dashboard FastAPI")
+    parser.add_argument(
+        "--redis-url",
+        default=os.getenv("REDIS_URL", "redis://localhost:6379"),
+        help="Redis URL (default: $REDIS_URL or redis://localhost:6379)",
+    )
+    parser.add_argument(
+        "--host",
+        default=os.getenv("FASTAPI_HOST", "0.0.0.0"),
+        help="Host to bind to (default: 0.0.0.0)",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=int(os.getenv("FASTAPI_PORT", 8000)),
+        help="Port to listen on (default: $FASTAPI_PORT or 8000)",
+    )
+    parser.add_argument(
+        "--prefix",
+        default="/rq",
+        help="URL prefix for the dashboard (default: /rq)",
+    )
+    args = parser.parse_args()
+
+    app = FastAPI()
+    dashboard = RedisQueueDashboard(redis_url=args.redis_url, prefix=args.prefix)
+    app.mount(args.prefix, dashboard)
+
+    uvicorn.run(app, host=args.host, port=args.port)


### PR DESCRIPTION
Adding arg parsing at startup to make development easier:

## Running Standalone

After installing, you can run the dashboard directly from the terminal:

```
$ rq-dashboard-fast
```

This starts the dashboard at `http://localhost:8000/rq` using Redis at `redis://localhost:6379`.

Available options:

```
$ rq-dashboard-fast --help
$ rq-dashboard-fast --redis-url redis://my-redis:6379 --port 9000
$ rq-dashboard-fast --host 127.0.0.1 --prefix /dashboard
```

| Flag | Default | Environment Variable |
|------|---------|---------------------|
| `--redis-url` | `redis://localhost:6379` | `REDIS_URL` |
| `--host` | `0.0.0.0` | `FASTAPI_HOST` |
| `--port` | `8000` | `FASTAPI_PORT` |
| `--prefix` | `/rq` | — |
